### PR TITLE
Correct dockerignore processing

### DIFF
--- a/src/main/java/com/microsoft/jenkins/acr/common/compression/IgnoreRule.java
+++ b/src/main/java/com/microsoft/jenkins/acr/common/compression/IgnoreRule.java
@@ -25,10 +25,10 @@ public class IgnoreRule {
 
         this.ignore = isIgnore;
 
-        String[] tokens = rule.split(Constants.FILE_SPERATE);
+        String[] tokens = rule.split(Constants.FILE_SPERATE, -1);
         for (int i = 0; i < tokens.length; i++) {
             String token = tokens[i];
-            if (token.equals("**")) {
+            if (token.equals("**") || (token.equals("") && i == tokens.length - 1)) {
                 tokens[i] = ".*";
             } else {
                 tokens[i] = token.replaceAll("\\*", "[^/]*")
@@ -36,5 +36,10 @@ public class IgnoreRule {
             }
         }
         this.pattern = "^" + StringUtils.join(tokens, '/') + "$";
+    }
+
+    @Override
+    public String toString() {
+        return "'" + pattern + "' ignored? " + ignore;
     }
 }


### PR DESCRIPTION
This PR fixes the processing order of the .dockerignore file to align it with the [Docker spec](https://docs.docker.com/engine/reference/builder/#dockerignore-file) and Azure CLI `az acr build`.

Previously, entries at the top of the file took highest precedence, while the updated approach is to have later entries in the file take higher precedence.

This PR fixes https://github.com/Azure/azure-acr-plugin/issues/19 and https://github.com/Azure/azure-acr-plugin/issues/49.

cc @xuzhang3 