### PR TITLE
Support environment variables in image names

### DIFF
--- a/src/main/resources/com/microsoft/jenkins/acr/QuickTaskBuilder/help-imageNames.html
+++ b/src/main/resources/com/microsoft/jenkins/acr/QuickTaskBuilder/help-imageNames.html
@@ -3,7 +3,20 @@
   ~ Licensed under the MIT License. See License.txt in the project root for license information.
   -->
 <div>
+    <p>
     After Azure Container Registry finishes building image, it pushes the image to registry with tags provided.
     Single Built image can be pushed with multiple repositories and tags.
+    </p>
+    <p>
+    Environment variables may be used in tag names - they will be replaced at build time. Examples:
+    </p>
+    <ul>
+        <li><code>repository:${ENV_VARIABLE}</code></li>
+        <li><code>repository:$ENV_VARIABLE</code></li>
+        <li><code>$ENV_VARIABLE:$ENV_VARIABLE</code></li>
+        <li><code>$ENV_VARIABLE</code></li>
+    </ul>
+    <p>
     If no image name provided, Azure Container Registry **<b>WILL NOT</b>** push any image to registry after building.
+    </p>
 </div>


### PR DESCRIPTION
This PR adds support for using environment variables in image names and resolves https://github.com/Azure/azure-acr-plugin/issues/38.

Environment variable expansion is accomplished using a Jenkins-provided utility class.

<a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/2243641/104110767-710f3880-52a0-11eb-8d7c-22c247140ce6.png"><img src="https://user-images.githubusercontent.com/2243641/104110767-710f3880-52a0-11eb-8d7c-22c247140ce6.png" alt="image" width="75%;"></a>
